### PR TITLE
Bytecoin exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The project is in early alpha deep development seems-like-its-working-oh-crap st
 Supported blockchains:
 
 * [Bitcoin](https://bitcoin.org/) (WIP)
+* [Bytecoin](https://bytecoin.org/)
 * [Ethereum](https://www.ethereum.org/)
 * [Cardano](https://www.cardanohub.org/)
 * [EOS](https://eos.io/) (WIP)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project is in early alpha deep development seems-like-its-working-oh-crap st
 Supported blockchains:
 
 * [Bitcoin](https://bitcoin.org/) (WIP)
-* [Bytecoin](https://bytecoin.org/)
+* [Bytecoin](https://bytecoin.org/) (WIP)
 * [Ethereum](https://www.ethereum.org/)
 * [Cardano](https://www.cardanohub.org/)
 * [EOS](https://eos.io/) (WIP)

--- a/coinmetrics-all-blockchains/CoinMetrics/BlockChain/All.hs
+++ b/coinmetrics-all-blockchains/CoinMetrics/BlockChain/All.hs
@@ -15,6 +15,9 @@ import CoinMetrics.BlockChain
 #if defined(CM_SUPPORT_BITCOIN)
 import CoinMetrics.Bitcoin
 #endif
+#if defined(CM_SUPPORT_BYTECOIN)
+import CoinMetrics.Bytecoin
+#endif
 #if defined(CM_SUPPORT_CARDANO)
 import CoinMetrics.Cardano
 #endif
@@ -52,6 +55,10 @@ allBlockChainInfos = HM.fromList infos
     infos =
 #if defined(CM_SUPPORT_BITCOIN)
       ("bitcoin",  SomeBlockChainInfo $ getBlockChainInfo (Proxy :: Proxy Bitcoin)) :
+#endif
+
+#if defined(CM_SUPPORT_BYTECOIN)
+      ("bytecoin",  SomeBlockChainInfo $ getBlockChainInfo (Proxy :: Proxy Bytecoin)) :
 #endif
 
 #if defined(CM_SUPPORT_CARDANO)

--- a/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
+++ b/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
@@ -16,6 +16,11 @@ flag bitcoin
   default:             True
   manual:              True
 
+flag waves
+  description:         Support Bytecoin
+  default:             True
+  manual:              True
+
 flag cardano
   description:         Support Cardano
   default:             True
@@ -78,6 +83,10 @@ library
   if flag(bitcoin)
     build-depends:       coinmetrics-bitcoin
     cpp-options:         -DCM_SUPPORT_BITCOIN
+
+  if flag(bytecoin)
+    build-depends:       coinmetrics-bytecoin
+    cpp-options:         -DCM_SUPPORT_BYTECOIN
 
   if flag(cardano)
     build-depends:       coinmetrics-cardano

--- a/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
+++ b/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
@@ -16,7 +16,7 @@ flag bitcoin
   default:             True
   manual:              True
 
-flag waves
+flag bytecoin
   description:         Support Bytecoin
   default:             True
   manual:              True

--- a/coinmetrics-bytecoin/CoinMetrics/Bytecoin.hs
+++ b/coinmetrics-bytecoin/CoinMetrics/Bytecoin.hs
@@ -31,22 +31,22 @@ import CoinMetrics.Util
 newtype Bytecoin = Bytecoin JsonRpc
 
 data BytecoinBlock = BytecoinBlock
-  { bc_difficulty :: {-# UNPACK #-} !Int64
-  , bc_hash :: {-# UNPACK #-} !HexString
-  , bc_height :: {-# UNPACK #-} !Int64
-  , bc_major_version :: {-# UNPACK #-} !Int64
-  , bc_minor_version :: {-# UNPACK #-} !Int64
-  , bc_nonce :: {-# UNPACK #-} !Int64
-  , bc_reward :: {-# UNPACK #-} !Int64
-  , bc_size :: {-# UNPACK #-} !Int64
-  , bc_timestamp :: {-# UNPACK #-} !Int64
-  , bc_coinbase_transaction :: !BytecoinTransaction
-  , bc_transactions :: !(V.Vector BytecoinTransaction)
+  { bb_difficulty :: {-# UNPACK #-} !Int64
+  , bb_hash :: {-# UNPACK #-} !HexString
+  , bb_height :: {-# UNPACK #-} !Int64
+  , bb_major_version :: {-# UNPACK #-} !Int64
+  , bb_minor_version :: {-# UNPACK #-} !Int64
+  , bb_nonce :: {-# UNPACK #-} !Int64
+  , bb_reward :: {-# UNPACK #-} !Int64
+  , bb_size :: {-# UNPACK #-} !Int64
+  , bb_timestamp :: {-# UNPACK #-} !Int64
+  , bb_coinbase_transaction :: !BytecoinTransaction
+  , bb_transactions :: !(V.Vector BytecoinTransaction)
   }
 
 instance IsBlock BytecoinBlock where
-  getBlockHeight = bc_height
-  getBlockTimestamp = posixSecondsToUTCTime . fromIntegral . bc_timestamp
+  getBlockHeight = bb_height
+  getBlockTimestamp = posixSecondsToUTCTime . fromIntegral . bb_timestamp
 
 newtype BytecoinBlockWrapper = BytecoinBlockWrapper
   { unwrapBytecoinBlock :: BytecoinBlock
@@ -67,13 +67,13 @@ instance J.FromJSON BytecoinBlockWrapper where
     <*> (V.map unwrapBytecoinTransaction <$> fields J..: "transactions")
 
 data BytecoinTransaction = BytecoinTransaction
-  { mt_extra :: {-# UNPACK #-} !HexString
-  , mt_fee :: !(Maybe Int64)
-  , mt_hash :: !(Maybe HexString)
-  , mt_inputs :: !(V.Vector BytecoinTransactionInput)
-  , mt_outputs :: !(V.Vector BytecoinTransactionOutput)
-  , mt_unlock_block_or_timestamp :: {-# UNPACK #-} !Int64
-  , mt_version :: {-# UNPACK #-} !Int64
+  { bt_extra :: {-# UNPACK #-} !HexString
+  , bt_fee :: !(Maybe Int64)
+  , bt_hash :: !(Maybe HexString)
+  , bt_inputs :: !(V.Vector BytecoinTransactionInput)
+  , bt_outputs :: !(V.Vector BytecoinTransactionOutput)
+  , bt_unlock_block_or_timestamp :: {-# UNPACK #-} !Int64
+  , bt_version :: {-# UNPACK #-} !Int64
   }
 
 newtype BytecoinTransactionWrapper = BytecoinTransactionWrapper
@@ -91,10 +91,10 @@ instance J.FromJSON BytecoinTransactionWrapper where
     <*> (fields J..: "version")
 
 data BytecoinTransactionInput = BytecoinTransactionInput
-  { mti_amount :: !(Maybe Int64)
-  , mti_height :: !(Maybe Int64)
-  , mti_key_image :: !(Maybe HexString)
-  , mti_output_indexes :: !(V.Vector Int64)
+  { bti_amount :: !(Maybe Int64)
+  , bti_height :: !(Maybe Int64)
+  , bti_key_image :: !(Maybe HexString)
+  , bti_output_indexes :: !(V.Vector Int64)
   }
 
 newtype BytecoinTransactionInputWrapper = BytecoinTransactionInputWrapper
@@ -112,8 +112,8 @@ instance J.FromJSON BytecoinTransactionInputWrapper where
       <*> (fromMaybe V.empty <$> traverse (J..: "output_indexes") maybeKey)
 
 data BytecoinTransactionOutput = BytecoinTransactionOutput
-  { mto_amount :: !Int64
-  , mto_key :: {-# UNPACK #-} !HexString
+  { bto_amount :: !Int64
+  , bto_key :: {-# UNPACK #-} !HexString
   }
 
 newtype BytecoinTransactionOutputWrapper = BytecoinTransactionOutputWrapper
@@ -126,7 +126,7 @@ instance J.FromJSON BytecoinTransactionOutputWrapper where
     <*> ((J..: "key") =<< fields J..: "target")
 
 genSchemaInstances [''BytecoinBlock, ''BytecoinTransaction, ''BytecoinTransactionInput, ''BytecoinTransactionOutput]
-genFlattenedTypes "height" [| bc_height |] [("block", ''BytecoinBlock), ("transaction", ''BytecoinTransaction), ("input", ''BytecoinTransactionInput), ("output", ''BytecoinTransactionOutput)]
+genFlattenedTypes "height" [| bb_height |] [("block", ''BytecoinBlock), ("transaction", ''BytecoinTransaction), ("input", ''BytecoinTransactionInput), ("output", ''BytecoinTransactionOutput)]
 
 instance BlockChain Bytecoin where
   type Block Bytecoin = BytecoinBlock

--- a/coinmetrics-bytecoin/CoinMetrics/Bytecoin.hs
+++ b/coinmetrics-bytecoin/CoinMetrics/Bytecoin.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE DeriveGeneric, OverloadedLists, OverloadedStrings, StandaloneDeriving, TemplateHaskell, TypeFamilies, ViewPatterns #-}
+
+module CoinMetrics.Bytecoin
+  ( Bytecoin(..)
+  , BytecoinBlock(..)
+  , BytecoinTransaction(..)
+  , BytecoinTransactionInput(..)
+  , BytecoinTransactionOutput(..)
+  ) where
+
+import qualified Data.Aeson as J
+import qualified Data.Aeson.Types as J
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Short as BS
+import qualified Data.Text.Encoding as T
+import qualified Data.HashMap.Lazy as HML
+import qualified Data.Vector as V
+import Data.Time.Clock.POSIX
+import Data.Maybe
+import Data.Int
+import Data.Proxy
+import Hanalytics.Schema
+
+import CoinMetrics.BlockChain
+import CoinMetrics.JsonRpc
+import CoinMetrics.Schema.Flatten
+import CoinMetrics.Schema.Util
+import CoinMetrics.Util
+
+newtype Bytecoin = Bytecoin JsonRpc
+
+data BytecoinBlock = BytecoinBlock
+  { bc_difficulty :: {-# UNPACK #-} !Int64
+  , bc_hash :: {-# UNPACK #-} !HexString
+  , bc_height :: {-# UNPACK #-} !Int64
+  , bc_major_version :: {-# UNPACK #-} !Int64
+  , bc_minor_version :: {-# UNPACK #-} !Int64
+  , bc_nonce :: {-# UNPACK #-} !Int64
+  , bc_reward :: {-# UNPACK #-} !Int64
+  , bc_size :: {-# UNPACK #-} !Int64
+  , bc_timestamp :: {-# UNPACK #-} !Int64
+  , bc_coinbase_transaction :: !BytecoinTransaction
+  , bc_transactions :: !(V.Vector BytecoinTransaction)
+  }
+
+instance IsBlock BytecoinBlock where
+  getBlockHeight = bc_height
+  getBlockTimestamp = posixSecondsToUTCTime . fromIntegral . bc_timestamp
+
+newtype BytecoinBlockWrapper = BytecoinBlockWrapper
+  { unwrapBytecoinBlock :: BytecoinBlock
+  }
+
+instance J.FromJSON BytecoinBlockWrapper where
+  parseJSON = J.withObject "bytecoin block" $ \fields -> fmap BytecoinBlockWrapper $ BytecoinBlock
+    <$> (fields J..: "difficulty")
+    <*> (fields J..: "hash")
+    <*> (fields J..: "height")
+    <*> (fields J..: "major_version")
+    <*> (fields J..: "minor_version")
+    <*> (fields J..: "nonce")
+    <*> (fields J..: "reward")
+    <*> (fields J..: "size")
+    <*> (fields J..: "timestamp")
+    <*> (unwrapBytecoinTransaction <$> fields J..: "coinbase_transaction")
+    <*> (V.map unwrapBytecoinTransaction <$> fields J..: "transactions")
+
+data BytecoinTransaction = BytecoinTransaction
+  { mt_extra :: {-# UNPACK #-} !HexString
+  , mt_fee :: !(Maybe Int64)
+  , mt_hash :: !(Maybe HexString)
+  , mt_inputs :: !(V.Vector BytecoinTransactionInput)
+  , mt_outputs :: !(V.Vector BytecoinTransactionOutput)
+  , mt_unlock_block_or_timestamp :: {-# UNPACK #-} !Int64
+  , mt_version :: {-# UNPACK #-} !Int64
+  }
+
+newtype BytecoinTransactionWrapper = BytecoinTransactionWrapper
+  { unwrapBytecoinTransaction :: BytecoinTransaction
+  }
+
+instance J.FromJSON BytecoinTransactionWrapper where
+  parseJSON = J.withObject "bytecoin transaction" $ \fields -> fmap BytecoinTransactionWrapper $ BytecoinTransaction
+    <$> (HexString . BS.toShort . B.pack <$> fields J..: "extra")
+    <*> (fields J..:? "fee")
+    <*> (fields J..:? "hash")
+    <*> (V.map unwrapBytecoinTransactionInput <$> fields J..: "inputs")
+    <*> (V.map unwrapBytecoinTransactionOutput <$> fields J..: "outputs")
+    <*> (fields J..: "unlock_block_or_timestamp")
+    <*> (fields J..: "version")
+
+data BytecoinTransactionInput = BytecoinTransactionInput
+  { mti_amount :: !(Maybe Int64)
+  , mti_height :: !(Maybe Int64)
+  , mti_key_image :: !(Maybe HexString)
+  , mti_output_indexes :: !(V.Vector Int64)
+  }
+
+newtype BytecoinTransactionInputWrapper = BytecoinTransactionInputWrapper
+  { unwrapBytecoinTransactionInput :: BytecoinTransactionInput
+  }
+
+instance J.FromJSON BytecoinTransactionInputWrapper where
+  parseJSON = J.withObject "bytecoin transaction input" $ \fields -> do
+    maybeKey <- fields J..:? "key"
+    maybeGen <- fields J..:? "gen"
+    fmap BytecoinTransactionInputWrapper $ BytecoinTransactionInput
+      <$> traverse (J..: "amount") maybeKey
+      <*> traverse (J..: "height") maybeGen
+      <*> traverse (J..: "key_image") maybeKey
+      <*> (fromMaybe V.empty <$> traverse (J..: "output_indexes") maybeKey)
+
+data BytecoinTransactionOutput = BytecoinTransactionOutput
+  { mto_amount :: !Int64
+  , mto_key :: {-# UNPACK #-} !HexString
+  }
+
+newtype BytecoinTransactionOutputWrapper = BytecoinTransactionOutputWrapper
+  { unwrapBytecoinTransactionOutput :: BytecoinTransactionOutput
+  }
+
+instance J.FromJSON BytecoinTransactionOutputWrapper where
+  parseJSON = J.withObject "bytecoin transaction output" $ \fields -> fmap BytecoinTransactionOutputWrapper $ BytecoinTransactionOutput
+    <$> (fields J..: "amount")
+    <*> ((J..: "key") =<< fields J..: "target")
+
+genSchemaInstances [''BytecoinBlock, ''BytecoinTransaction, ''BytecoinTransactionInput, ''BytecoinTransactionOutput]
+genFlattenedTypes "height" [| bc_height |] [("block", ''BytecoinBlock), ("transaction", ''BytecoinTransaction), ("input", ''BytecoinTransactionInput), ("output", ''BytecoinTransactionOutput)]
+
+instance BlockChain Bytecoin where
+  type Block Bytecoin = BytecoinBlock
+
+  getBlockChainInfo _ = BlockChainInfo
+    { bci_init = \BlockChainParams
+      { bcp_httpManager = httpManager
+      , bcp_httpRequest = httpRequest
+      } -> return $ Bytecoin $ newJsonRpc httpManager httpRequest Nothing
+    , bci_defaultApiUrl = "http://127.0.0.1:8081/json_rpc"
+    , bci_defaultBeginBlock = 0
+    , bci_defaultEndBlock = -60 -- conservative rewrite limit
+    , bci_schemas = standardBlockChainSchemas
+      (schemaOf (Proxy :: Proxy BytecoinBlock))
+      [ schemaOf (Proxy :: Proxy BytecoinTransactionInput)
+      , schemaOf (Proxy :: Proxy BytecoinTransactionOutput)
+      , schemaOf (Proxy :: Proxy BytecoinTransaction)
+      ]
+      "CREATE TABLE \"bytecoin\" OF \"BytecoinBlock\" (PRIMARY KEY (\"height\"));"
+    , bci_flattenSuffixes = ["blocks", "transactions", "inputs", "outputs"]
+    , bci_flattenPack = let
+      f (blocks, (transactions, inputs, outputs)) =
+        [ SomeBlocks (blocks :: [BytecoinBlock_flattened])
+        , SomeBlocks (transactions :: [BytecoinTransaction_flattened])
+        , SomeBlocks (inputs :: [BytecoinTransactionInput_flattened])
+        , SomeBlocks (outputs :: [BytecoinTransactionOutput_flattened])
+        ]
+      in f . mconcat . map flatten
+    }
+
+  getCurrentBlockHeight (Bytecoin jsonRpc) =
+    either fail (return . (+ (-1))) . J.parseEither (J..: "count") =<< jsonRpcRequest jsonRpc "getblockcount" J.Null
+
+  getBlockByHeight (Bytecoin jsonRpc) blockHeight = do
+    blockInfo <- jsonRpcRequest jsonRpc "getrawblock" (J.Object [("height", J.toJSON blockHeight)])
+    J.Object blockHeaderFields <- either fail return $ J.parseEither (J..: "block_header") blockInfo
+    Just (J.Bool False) <- return $ HML.lookup "orphan_status" blockHeaderFields
+    Just blockHash <- return $ HML.lookup "hash" blockHeaderFields
+    Just blockDifficulty <- return $ HML.lookup "difficulty" blockHeaderFields
+    Just blockReward <- return $ HML.lookup "reward" blockHeaderFields
+    Just blockSize <- return $ HML.lookup "block_size" blockHeaderFields
+    blockJsonFields <- either fail return $ ((J.eitherDecode' . BL.fromStrict . T.encodeUtf8) =<<) $ J.parseEither (J..: "json") blockInfo
+    transactionHashes <- either fail return $ J.parseEither (J..: "transaction_hashes") blockJsonFields
+    transactions <- if V.null transactionHashes
+      then return V.empty
+      else do
+        transactionsJsons <- either fail return . J.parseEither (J..: "txs_as_json") =<< nonJsonRpcRequest jsonRpc "/gettransactions" (J.Object [("transaction_hashes", J.Array transactionHashes), ("decode_as_json", J.Bool True)])
+        V.forM (V.zip transactionHashes transactionsJsons) $ \(txHash, transactionJson) -> do
+          transactionFields <- either fail return $ J.eitherDecode' $ BL.fromStrict $ T.encodeUtf8 transactionJson
+          return $ J.Object $ HML.insert "hash" txHash transactionFields
+    let
+      jsonBlock = J.Object
+        $ HML.insert "height" (J.toJSON blockHeight)
+        $ HML.insert "hash" blockHash
+        $ HML.insert "difficulty" blockDifficulty
+        $ HML.insert "reward" blockReward
+        $ HML.insert "size" blockSize
+        $ HML.insert "transactions" (J.Array transactions)
+        blockJsonFields
+    case J.fromJSON jsonBlock of
+      J.Success block -> return $ unwrapBytecoinBlock block
+      J.Error err -> fail err
+
+  blockHeightFieldName _ = "height"

--- a/coinmetrics-bytecoin/coinmetrics-bytecoin.cabal
+++ b/coinmetrics-bytecoin/coinmetrics-bytecoin.cabal
@@ -1,0 +1,30 @@
+name:                coinmetrics-bytecoin
+version:             0.1.0.0
+-- synopsis:            
+-- description:         
+license:             MIT
+author:              Adam Tache
+maintainer:          adamtache@gmail.com
+-- copyright:           
+category:            Cryptocurrency
+build-type:          Simple
+-- extra-source-files:  
+cabal-version:       >=1.10
+
+library
+  exposed-modules:
+    CoinMetrics.Bytecoin
+  build-depends:
+    aeson
+    , base
+    , bytestring
+    , coinmetrics
+    , hanalytics-base
+    , http-client
+    , memory
+    , text
+    , time
+    , unordered-containers
+    , vector
+  ghc-options:         -Wall
+  default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - coinmetrics
 - coinmetrics-all-blockchains
 - coinmetrics-bitcoin
+- coinmetrics-bytecoin
 - coinmetrics-cardano
 - coinmetrics-eos
 - coinmetrics-ethereum


### PR DESCRIPTION
***Background***
- [Bytecoin Repo](https://github.com/bcndev/bytecoin)
- Bytecoin and Monero are both built using the CryptoNote protocol.
- There is significant overlap in block and transaction data between the two.
- Therefore, this exporter is a modified version of the [coinmetrics-monero](https://github.com/coinmetrics-io/haskell-tools/tree/master/coinmetrics-monero) exporter.

***Links***
- Bytecoin Node Daemon JSON RPC API ([Wiki](https://github.com/bcndev/bytecoin/wiki/Bytecoin-Node-Daemon-JSON-RPC-API))
- [Block data](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L220)
- [Transaction data](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L161)
- [Transaction output data](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L147)
- [Transaction input data](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L153)

***Change***
In comparison to the Monero codebase, Bytecoin stores:

1. `miner_tx` as `coinbase_transaction` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L263).
2. `vin` as `inputs` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L164)
3. `vout` as `outputs` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L165)
4. `unlock_time` as `unlock_block_or_timestamp` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L163). The team [deprecated](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/rpc_api.cpp#L143) `unlock_time`. 
5. `kimage` as `key_image` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L156)
6. `tx_hashes` as `transaction_hashes` - [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L382)

Bytecoin does not store:
1. `key_offsets` - [Source](https://github.com/bcndev/bytecoin/search?utf8=%E2%9C%93&q=key_offsets&type=)
7. `rct_signatures` - [Source](https://github.com/bcndev/bytecoin/search?utf8=%E2%9C%93&q=rct_signatures&type=)

- Added `output_indexes` to transaction inputs. [Source](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/CryptoNote.cpp#L155)

Node JSON RPC API calls are located [here](https://github.com/bcndev/bytecoin/blob/32344c1482a3b87b503e5c9cdbba484197f87ba4/src/Core/Node.cpp#L268):
- Default port is `8081`.
- `get_status`

***TODO***
1. Proper RPC calls
2. Testing

***Testing***
```
docker pull quay.io/coinmetrics/haskell-tools
docker run -it --rm --net host quay.io/coinmetrics/haskell-tools coinmetrics-export print-schema --schema bytecoin --storage postgres

coinmetrics-export export --blockchain bytecoin \
  --continue --threads 16 \
  --output-postgres "host=127.0.0.1 user=postgres"
```