### PR TITLE
Support bitcoincash as forkcoin from bitcoin

### DIFF
--- a/coinmetrics-all-blockchains/CoinMetrics/BlockChain/All.hs
+++ b/coinmetrics-all-blockchains/CoinMetrics/BlockChain/All.hs
@@ -12,7 +12,7 @@ import qualified Data.Text as T
 
 import CoinMetrics.BlockChain
 
-#if defined(CM_SUPPORT_BITCOIN)
+#if defined(CM_SUPPORT_BITCOIN) || defined(CM_SUPPORT_BITCOINCASH)
 import CoinMetrics.Bitcoin
 #endif
 #if defined(CM_SUPPORT_CARDANO)
@@ -58,6 +58,10 @@ allBlockChainInfos = HM.fromList infos
     infos =
 #if defined(CM_SUPPORT_BITCOIN)
       ("bitcoin",  SomeBlockChainInfo $ getBlockChainInfo (Proxy :: Proxy Bitcoin)) :
+#endif
+
+#if defined(CM_SUPPORT_BITCOINCASH)
+      ("bitcoincash",  SomeBlockChainInfo $ getBlockChainInfoByFork (Proxy :: Proxy Bitcoin) (Just "bitcoincash")) :
 #endif
 
 #if defined(CM_SUPPORT_CARDANO)

--- a/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
+++ b/coinmetrics-all-blockchains/coinmetrics-all-blockchains.cabal
@@ -16,6 +16,11 @@ flag bitcoin
   default:             True
   manual:              True
 
+flag bitcoincash
+  description:         Support BitcoinCash
+  default:             True
+  manual:              True
+
 flag cardano
   description:         Support Cardano
   default:             True
@@ -88,6 +93,10 @@ library
   if flag(bitcoin)
     build-depends:       coinmetrics-bitcoin
     cpp-options:         -DCM_SUPPORT_BITCOIN
+
+  if flag(bitcoincash)
+    build-depends:       coinmetrics-bitcoin
+    cpp-options:         -DCM_SUPPORT_BITCOINCASH
 
   if flag(cardano)
     build-depends:       coinmetrics-cardano

--- a/coinmetrics-bitcoin/CoinMetrics/Bitcoin.hs
+++ b/coinmetrics-bitcoin/CoinMetrics/Bitcoin.hs
@@ -162,7 +162,9 @@ genFlattenedTypes "height" [| bb_height |] [("block", ''BitcoinBlock), ("transac
 instance BlockChain Bitcoin where
   type Block Bitcoin = BitcoinBlock
 
-  getBlockChainInfo _ = BlockChainInfo
+  getBlockChainInfo p = getBlockChainInfoByFork p Nothing
+
+  getBlockChainInfoByFork _ forkName = BlockChainInfo
     { bci_init = \BlockChainParams
       { bcp_httpManager = httpManager
       , bcp_httpRequest = httpRequest
@@ -177,7 +179,11 @@ instance BlockChain Bitcoin where
       , schemaOf (Proxy :: Proxy BitcoinVout)
       , schemaOf (Proxy :: Proxy BitcoinTransaction)
       ]
-      "CREATE TABLE \"bitcoin\" OF \"BitcoinBlock\" (PRIMARY KEY (\"height\"));"
+      ( case forkName of 
+          Just "bitcoincash" -> "CREATE TABLE \"bitcoincash\" OF \"BitcoinBlock\" (PRIMARY KEY (\"height\"));"
+          Just _ -> undefined
+          Nothing -> "CREATE TABLE \"bitcoin\" OF \"BitcoinBlock\" (PRIMARY KEY (\"height\"));"
+      )
     , bci_flattenSuffixes = ["blocks", "transactions", "vins", "vouts"]
     , bci_flattenPack = let
       f (blocks, (transactions, vins, vouts)) =

--- a/coinmetrics/CoinMetrics/BlockChain.hs
+++ b/coinmetrics/CoinMetrics/BlockChain.hs
@@ -33,6 +33,9 @@ class (HasBlockHeader (Block a), Schemable (Block a), A.ToAvro (Block a), ToPost
 
   getBlockChainInfo :: Proxy a -> BlockChainInfo a
 
+  getBlockChainInfoByFork :: Proxy a -> Maybe String -> BlockChainInfo a
+  getBlockChainInfoByFork p _ = getBlockChainInfo p
+
   getCurrentBlockHeight :: a -> IO BlockHeight
 
   getBlockHeaderByHeight :: a -> BlockHeight -> IO BlockHeader


### PR DESCRIPTION
Support bitcoincash by using the existing 'bitcoin' library, since they share the same API, assuming BitcoinABC client in mind. 